### PR TITLE
feat: Implement Choose Your Symbol (X or O)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A modern implementation of the classic Tic Tac Toe game built with React, TypeSc
 - **Sound Effects:** Audible feedback for game actions (moves, wins, draws, button clicks). Includes a toggle button (volume icon) in the header to mute/unmute sounds.
 - **Detailed Game Statistics:** Tracks your performance with stats for total games played, plus separate win, loss (for Player X in PvA), and draw counts for both "Player vs Player" and "Player vs AI" game modes. Statistics are saved locally in your browser.
 - **Game Replay (History View):** Review your past games move by move! Click on any game in the "Game History" list to enter replay mode. Use the "Previous Move" and "Next Move" buttons to step through the board states of that game. Click "Return to Current Game" to exit the replay.
+- **Choose Your Symbol:** Select whether you want to play as 'X' or 'O' at the start of a new game. The game will adjust turn order, AI opponent's symbol, and display accordingly.
 
 ## Technologies Used
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,12 @@ function App() {
   const [gameStatus, setGameStatus] = useState<'playing' | 'won' | 'draw'>('playing');
   const [winningLine, setWinningLine] = useState<number[] | null>(null);
 
+  // State for human player's symbol choice
+  const [humanPlayerSymbol, setHumanPlayerSymbol] = useState<PlayerSymbol>(() => {
+    const storedSymbol = localStorage.getItem('ticTacToeHumanSymbol') as PlayerSymbol | null;
+    return storedSymbol || 'X'; // Default to 'X'
+  });
+
   // State for viewing game history
   const [viewingHistoryGame, setViewingHistoryGame] = useState<HistoricGame | null>(null);
   const [historyStep, setHistoryStep] = useState<number>(0);
@@ -59,6 +65,11 @@ function App() {
   useEffect(() => {
     localStorage.setItem('ticTacToeGameHistory', JSON.stringify(gameHistory));
   }, [gameHistory]);
+
+  // Persist humanPlayerSymbol to localStorage
+  useEffect(() => {
+    localStorage.setItem('ticTacToeHumanSymbol', humanPlayerSymbol);
+  }, [humanPlayerSymbol]);
 
   // Check for winner or draw & update gameStats and gameHistory
   useEffect(() => {


### PR DESCRIPTION
This commit introduces the ability for players to choose whether they want to play as 'X' or 'O'.

Key changes:
- Added state in App.tsx to store the human player's chosen symbol (`humanPlayerSymbol`), persisted to localStorage.
- Implemented UI buttons allowing you to select 'X' or 'O' before a game starts. This choice is disabled once a game is in progress or when viewing history.
- Adapted game logic:
  - The starting player in `resetGame` is now determined by `humanPlayerSymbol`.
  - AI opponent logic correctly identifies its symbol based on the human's choice and takes turns accordingly.
  - Status messages (`getStatusMessage`) now provide clear, dynamic feedback based on the human player's chosen symbol (e.g., "Your Turn (Symbol)", win/loss messages).
- Updated statistics logic:
  - The `GameStats` interface in `src/types.ts` and its usage in App.tsx and ScoreBoard.tsx were modified to track Player vs AI wins as `humanWins` and `aiWins`, ensuring correct attribution regardless of the symbol chosen by the human.
- Refined UI for clarity:
  - Player name input labels and disabling logic in App.tsx are now more dynamic based on the chosen symbol and game mode (PvP/PvA).
  - ScoreBoard.tsx now correctly displays player names (indicating "(You)") and AI identifiers alongside their chosen/assigned symbols and relevant scores.
- Added comprehensive unit tests for the "Choose Your Symbol" functionality, covering state changes, game logic adaptations, statistics, and UI display updates.
- Updated README.md to describe the new feature.

Players now have more control over their gameplay experience by selecting their preferred symbol.