### PR TITLE
fix: Improve responsiveness of game board and mini-board

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -23,7 +23,7 @@ const Board: React.FC<BoardProps> = ({ board: squares, winningLine, onSquareClic
   }
 
   return (
-    <div className={`grid grid-cols-3 gap-1 w-64 h-64 mx-auto rounded-lg shadow-inner p-1 bg-gray-200 dark:bg-gray-700`}>
+    <div className={`grid grid-cols-3 gap-1 w-full aspect-square max-w-sm mx-auto rounded-lg shadow-inner p-1 bg-gray-200 dark:bg-gray-700`}>
       {squares.map((squareValue, i) => {
         // If squares was undefined, .map() would have thrown "Cannot read properties of undefined (reading 'map')"
         // So, if we are here, squares is an array.

--- a/src/components/GameHistory.tsx
+++ b/src/components/GameHistory.tsx
@@ -63,7 +63,7 @@ const GameHistory: React.FC<GameHistoryProps> = ({ history, onViewHistoricGame }
                 </div>
                 {/* Mini-board display */}
                 <div 
-                  className="mt-2 grid grid-cols-3 gap-0.5 w-16 h-16 border border-gray-300 dark:border-slate-600 bg-gray-100 dark:bg-slate-700 p-0.5 rounded"
+                  className="mt-2 grid grid-cols-3 gap-0.5 w-14 h-14 sm:w-16 sm:h-16 border border-gray-300 dark:border-slate-600 bg-gray-100 dark:bg-slate-700 p-0.5 rounded"
                   data-testid="mini-board-display"
                 >
                   {finalBoardState.map((square, i) => (


### PR DESCRIPTION
This commit addresses responsiveness issues, primarily for the main game board, to ensure better scaling on smaller screen sizes.

Key changes:

-   **`src/components/Board.tsx`:**
    -   Replaced fixed sizing (`w-64 h-64`) with responsive Tailwind CSS classes (`w-full aspect-square max-w-sm mx-auto`).
    -   The board now scales fluidly with the viewport width while maintaining its aspect ratio, up to a maximum width of `sm` (24rem).
    -   This prevents overflow on small screens and allows the board to utilize space more effectively.

-   **`src/components/GameHistory.tsx`:**
    -   Adjusted the mini-board size from a fixed `w-16 h-16` to `w-14 h-14 sm:w-16 sm:h-16`.
    -   This makes the mini-board slightly smaller on very small screens, improving layout, while retaining its original size on screens `sm` and wider.

These changes enhance the user experience on devices with smaller viewports by ensuring the game's core interactive element (the board) adapts correctly.