### PR TITLE
fix: Repair theme switching and persistence

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,16 +10,26 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<Theme>('light'); // Default theme
+  const [theme, setTheme] = useState<Theme>(() => {
+    const storedTheme = localStorage.getItem('theme') as Theme | null;
+    if (storedTheme && (storedTheme === 'light' || storedTheme === 'dark')) {
+      return storedTheme;
+    }
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light'; // Default theme
+  });
 
   useEffect(() => {
-    // On theme change, update the class on the root <html> element
+    // On theme change, update the class on the root <html> element and persist
     const root = window.document.documentElement;
     if (theme === 'dark') {
       root.classList.add('dark');
     } else {
       root.classList.remove('dark');
     }
+    localStorage.setItem('theme', theme);
   }, [theme]);
 
   const toggleTheme = () => {


### PR DESCRIPTION
This commit fixes the theme switching functionality to correctly initialize the theme from localStorage or system preference, and to persist user-selected themes across sessions.

Key changes in `src/contexts/ThemeContext.tsx`:

-   **Theme Initialization:** The `theme` state is now initialized by:
    1.  Checking `localStorage.getItem('theme')` for a valid saved theme.
    2.  If not found, checking `window.matchMedia('(prefers-color-scheme: dark)').matches` for system preference.
    3.  Defaulting to 'light' if neither is set.
-   **Theme Persistence:** The `useEffect` hook that applies the 'dark' class to `document.documentElement` now also saves the current theme to `localStorage.setItem('theme', theme)`.

This ensures that your selected light or dark theme is correctly loaded, applied, and remembered between visits.